### PR TITLE
Hotfix: List margin

### DIFF
--- a/_sass/vix-wiki.scss
+++ b/_sass/vix-wiki.scss
@@ -76,6 +76,10 @@ hr {
     margin-top: 30px;
 }
 
+ul {
+    margin-left: 20px;
+}
+
 a {
     text-decoration: underline;
 }


### PR DESCRIPTION
Added a margin-left to lists so that they line up correctly with the body text. 

Closes #40